### PR TITLE
Added Option<>.get() that throws on none() instances

### DIFF
--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -6,6 +6,7 @@ abstract class Option<A> extends TraversableOps<Option, A> with FunctorOps<Optio
   B cata<B, B2 extends B>(B ifNone(), B2 ifSome(A a)) => fold(ifNone, ifSome);
   Option<A> orElse(Option<A> other()) => fold(other, (_) => this);
   A getOrElse(A dflt()) => fold(dflt, (a) => a);
+  A get() => getOrElse(() => throw StateError("Unexpectedly empty Option: $this"));
   Either<B, A> toEither<B>(B ifNone()) => fold(() => left(ifNone()), (a) => right(a));
   Either<dynamic, A> operator %(ifNone) => toEither(() => ifNone);
   A operator |(A dflt) => getOrElse(() => dflt);


### PR DESCRIPTION
This can be usually avoided with fold(), Option.map2() etc., but there
are still cases where it's otherwise known that given instance of
Option<> is some() and then this shorthand can be useful.