### PR TITLE
Deprecated file mode

### DIFF
--- a/lib/src/builtins.dart
+++ b/lib/src/builtins.dart
@@ -71,11 +71,7 @@ final Order<double> DoubleOrder = new ComparableOrder<double>();
 
 final Order<String> StringOrder = new ComparableOrder<String>();
 
-A cast<A>(dynamic a) {
-  // ignore: invalid_assignment
-  final A ca = a;
-  return ca;
-}
+A cast<A>(dynamic a) => a as A;
 
 class IteratorEq<A> extends Eq<Iterator<A>> {
   final Eq<A> _aEq;

--- a/lib/src/unsafe/io.dart
+++ b/lib/src/unsafe/io.dart
@@ -24,7 +24,7 @@ Future unsafeIOInterpreter(IOOp io) {
     return new Future.error(io.failure);
 
   } else if (io is OpenFile) {
-    return new File(io.path).open(mode: io.openForRead ? FileMode.READ : FileMode.WRITE).then((f) => new _RandomAccessFileRef(f));
+    return new File(io.path).open(mode: io.openForRead ? FileMode.read : FileMode.write).then((f) => new _RandomAccessFileRef(f));
 
   } else if (io is CloseFile) {
     return unwrapFileRef(io.file).then((f) => f.close().then((_) => unit));


### PR DESCRIPTION
Fixes:

*   Using FileMode.read and FileMode.write instead of deprecated FileMode.READ and FileMode.WRITE
*   Rewriting cast\<A>() function for avoid language errors.