### PR TITLE
Bind map

### DIFF
--- a/lib/src/builtins.dart
+++ b/lib/src/builtins.dart
@@ -71,11 +71,7 @@ final Order<double> DoubleOrder = new ComparableOrder<double>();
 
 final Order<String> StringOrder = new ComparableOrder<String>();
 
-A cast<A>(dynamic a) {
-  // ignore: invalid_assignment
-  final A ca = a;
-  return ca;
-}
+A cast<A>(dynamic a) => a as A;
 
 class IteratorEq<A> extends Eq<Iterator<A>> {
   final Eq<A> _aEq;

--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -163,7 +163,7 @@ abstract class Either<L, R> implements TraversableMonadOps<Either<L, dynamic>, R
 
   @override Either<L, Tuple2<R, B>> strengthR<B>(B b) => map((a) => tuple2(a, b));
 
-  @override Either<L, B> ap<B>(Either<L, Function1<R, B>> ff) => ff.bind((f) => map(f));
+  @override Either<L, B> ap<B>(Either<L, Function1<R, B>> ff) => ff.bind(map);
 
   // PURISTS BEWARE: side effecty stuff below -- proceed with caution!
 

--- a/lib/src/evaluation.dart
+++ b/lib/src/evaluation.dart
@@ -69,7 +69,7 @@ class Evaluation<E, R, W, S, A> implements MonadOps<Evaluation<E, R, W, S, dynam
 
   @override Evaluation<E, R, W, S, Tuple2<A, B>> strengthR<B>(B b) => map((a) => tuple2(a, b));
 
-  @override Evaluation<E, R, W, S, B> ap<B>(Evaluation<E, R, W, S, Function1<A, B>> ff) => ff.bind((f) => map(f)); // TODO: optimize
+  @override Evaluation<E, R, W, S, B> ap<B>(Evaluation<E, R, W, S, Function1<A, B>> ff) => ff.bind(map); // TODO: optimize
 }
 
 class EvaluationMonad<E, R, W, S> extends Object with Functor<Evaluation<E, R, W, S, dynamic>>, Applicative<Evaluation<E, R, W, S, dynamic>>, Monad<Evaluation<E, R, W, S, dynamic>> {

--- a/lib/src/free.dart
+++ b/lib/src/free.dart
@@ -101,7 +101,7 @@ abstract class Free<F, A> implements MonadOps<Free<F, dynamic>, A> {
 
   static Free<F, Unit> ifM<F>(Free<F, bool> fbool, Free<F, Unit> ifTrue) => fbool.flatMap((bool b) => b ? ifTrue : new Pure(unit));
 
-  @override Free<F, B> ap<B>(Free<F, Function1<A, B>> ff) => ff.bind((f) => map(f)); // TODO: optimize
+  @override Free<F, B> ap<B>(Free<F, Function1<A, B>> ff) => ff.bind(map); // TODO: optimize
 
   @override Free<F, Tuple2<B, A>> strengthL<B>(B b) => map((a) => tuple2(b, a));
 

--- a/lib/src/ilist.dart
+++ b/lib/src/ilist.dart
@@ -352,7 +352,7 @@ abstract class IList<A> implements TraversableMonadPlusOps<IList, A> {
 
   @override bool any(bool f(A a)) => foldMap(BoolOrMi, f); // TODO: optimize
 
-  @override IList<B> ap<B>(IList<Function1<A, B>> ff) => ff.bind((f) => map(f)); // TODO: optimize
+  @override IList<B> ap<B>(IList<Function1<A, B>> ff) => ff.bind(map); // TODO: optimize
 
   @override A concatenate(Monoid<A> mi) => foldMap(mi, id);
 

--- a/lib/src/ivector.dart
+++ b/lib/src/ivector.dart
@@ -158,7 +158,7 @@ class IVector<A> implements TraversableMonadPlusOps<IVector, A> {
 
   @override IVector<B> andThen<B>(IVector<B> next) => bind((_) => next);
 
-  @override IVector<B> ap<B>(IVector<Function1<A, B>> ff) => ff.bind((f) => map(f)); // TODO: optimize
+  @override IVector<B> ap<B>(IVector<Function1<A, B>> ff) => ff.bind(map); // TODO: optimize
 
   @override IVector<B> replace<B>(B replacement) => map((_) => replacement);
 

--- a/lib/src/monad.dart
+++ b/lib/src/monad.dart
@@ -30,7 +30,7 @@ abstract class MonadOps<F, A> implements ApplicativeOps<F, A> {
   F bind<B>(covariant F f(A a));
 
   @override F map<B>(B f(A a));// => bind((a) => pure(f(a)));
-  @override F ap<B>(covariant F ff) => cast<MonadOps<F, Function1<A, B>>>(ff).bind((f) => map(f));
+  @override F ap<B>(covariant F ff) => cast<MonadOps<F, Function1<A, B>>>(ff).bind(map);
   F flatMap<B>(covariant F f(A a)) => bind(f);
   F andThen<B>(covariant F next) => bind((_) => next);
   F replace<B>(B replacement) => map((_) => replacement);

--- a/lib/src/state.dart
+++ b/lib/src/state.dart
@@ -13,27 +13,43 @@ class State<S, A> implements MonadOps<State<S, dynamic>, A> {
   State(this._run);
 
   State<S, B> pure<B>(B b) => new State((s) => new Tuple2(b, s));
-  @override State<S, B> map<B>(B f(A a)) => new State((S s) => run(s).map1(f));
-  @override State<S, B> bind<B>(Function1<A, State<S, B>> f) => new State((S s) {
-    final ran = run(s);
-    return f(ran.value1).run(ran.value2);
-  });
-  @override State<S, B> flatMap<B>(Function1<A, State<S, B>> f) => bind(f);
-  @override State<S, B> andThen<B>(State<S, B> next) => bind((_) => next);
+  @override
+  State<S, B> map<B>(B f(A a)) => new State((S s) => run(s).map1(f));
+  @override
+  State<S, B> bind<B>(Function1<A, State<S, B>> f) => new State((S s) {
+        final ran = run(s);
+        return f(ran.value1).run(ran.value2);
+      });
+  @override
+  State<S, B> flatMap<B>(Function1<A, State<S, B>> f) => bind(f);
+  @override
+  State<S, B> andThen<B>(State<S, B> next) => bind((_) => next);
 
-  @override State<S, Tuple2<B, A>> strengthL<B>(B b) => map((a) => tuple2(b, a));
+  @override
+  State<S, Tuple2<B, A>> strengthL<B>(B b) => map((a) => tuple2(b, a));
 
-  @override State<S, Tuple2<A, B>> strengthR<B>(B b) => map((a) => tuple2(a, b));
+  @override
+  State<S, Tuple2<A, B>> strengthR<B>(B b) => map((a) => tuple2(a, b));
 
-  @override State<S, B> ap<B>(State<S, Function1<A, B>> ff) => ff.bind((f) => map(f)); // TODO: optimize
+  @override
+  State<S, B> ap<B>(State<S, Function1<A, B>> ff) =>
+      ff.bind(map); // TODO: optimize
 
-  @override State<S, B> replace<B>(B replacement) => map((_) => replacement);
+  @override
+  State<S, B> replace<B>(B replacement) => map((_) => replacement);
 }
 
-class StateMonad<S> extends Functor<State<S, dynamic>> with Applicative<State<S, dynamic>>, Monad<State<S, dynamic>> {
-  @override State<S, A> pure<A>(A a) => new State((S s) => new Tuple2(a, s));
-  @override State<S, B> map<A, B>(covariant State<S, A> fa, covariant B f(A a)) => fa.map(f);
-  @override State<S, B> bind<A, B>(covariant State<S, A> fa, covariant Function1<A, State<S, B>> f) => fa.bind(f);
+class StateMonad<S> extends Functor<State<S, dynamic>>
+    with Applicative<State<S, dynamic>>, Monad<State<S, dynamic>> {
+  @override
+  State<S, A> pure<A>(A a) => new State((S s) => new Tuple2(a, s));
+  @override
+  State<S, B> map<A, B>(covariant State<S, A> fa, covariant B f(A a)) =>
+      fa.map(f);
+  @override
+  State<S, B> bind<A, B>(
+          covariant State<S, A> fa, covariant Function1<A, State<S, B>> f) =>
+      fa.bind(f);
 
   State<S, S> get() => new State((S s) => new Tuple2(s, s));
   State<S, A> gets<A>(A f(S s)) => new State((S s) => new Tuple2(f(s), s));
@@ -54,34 +70,59 @@ class StateT<F, S, A> implements MonadOps<StateT<F, S, dynamic>, A> {
   F value(S s) => _FM.map(_run(s), (t) => t.value1);
   F state(S s) => _FM.map(_run(s), (t) => t.value2);
 
-  StateT<F, S, B> pure<B>(B b) => new StateT(_FM, (S s) => _FM.pure(new Tuple2(b, s)));
-  @override StateT<F, S, B> map<B>(B f(A a)) => new StateT(_FM, (S s) => _FM.map(_run(s), (Tuple2<A, B> t) => t.map1(f)));
-  @override StateT<F, S, B> bind<B>(Function1<A, StateT<F, S, B>> f) => new StateT(_FM, (S s) => _FM.bind(_FM.pure(() => _run(s)), (F tt()) {
-    return _FM.bind(tt(), (Tuple2<A, S> t) => f(t.value1)._run(t.value2));
-  }));
-  @override StateT<F, S, B> flatMap<B>(Function1<A, StateT<F, S, B>> f) => bind(f);
-  @override StateT<F, S, B> andThen<B>(StateT<F, S, B> next) => bind((_) => next);
-  @override StateT<F, S, B> replace<B>(B b) => map((_) => b);
-  @override StateT<F, S, B> ap<B>(StateT<F, S, Function1<A, B>> ff) => ff.bind((f) => map(f)); // TODO: optimize
+  StateT<F, S, B> pure<B>(B b) =>
+      new StateT(_FM, (S s) => _FM.pure(new Tuple2(b, s)));
+  @override
+  StateT<F, S, B> map<B>(B f(A a)) =>
+      new StateT(_FM, (S s) => _FM.map(_run(s), (Tuple2<A, B> t) => t.map1(f)));
+  @override
+  StateT<F, S, B> bind<B>(Function1<A, StateT<F, S, B>> f) => new StateT(
+      _FM,
+      (S s) => _FM.bind(_FM.pure(() => _run(s)), (F tt()) {
+            return _FM.bind(
+                tt(), (Tuple2<A, S> t) => f(t.value1)._run(t.value2));
+          }));
+  @override
+  StateT<F, S, B> flatMap<B>(Function1<A, StateT<F, S, B>> f) => bind(f);
+  @override
+  StateT<F, S, B> andThen<B>(StateT<F, S, B> next) => bind((_) => next);
+  @override
+  StateT<F, S, B> replace<B>(B b) => map((_) => b);
+  @override
+  StateT<F, S, B> ap<B>(StateT<F, S, Function1<A, B>> ff) =>
+      ff.bind(map); // TODO: optimize
 
-  @override StateT<F, S, Tuple2<B, A>> strengthL<B>(B b) => map((a) => tuple2(b, a));
+  @override
+  StateT<F, S, Tuple2<B, A>> strengthL<B>(B b) => map((a) => tuple2(b, a));
 
-  @override StateT<F, S, Tuple2<A, B>> strengthR<B>(B b) => map((a) => tuple2(a, b));
+  @override
+  StateT<F, S, Tuple2<A, B>> strengthR<B>(B b) => map((a) => tuple2(a, b));
 }
 
-class StateTMonad<F, S> extends Functor<StateT<F, S, dynamic>> with Applicative<StateT<F, S, dynamic>>, Monad<StateT<F, S, dynamic>> {
+class StateTMonad<F, S> extends Functor<StateT<F, S, dynamic>>
+    with Applicative<StateT<F, S, dynamic>>, Monad<StateT<F, S, dynamic>> {
   final Monad<F> _FM;
 
   StateTMonad(this._FM);
 
-  @override StateT<F, S, A> pure<A>(A a) =>  new StateT(_FM, (S s) => _FM.pure(new Tuple2(a, s)));
-  @override StateT<F, S, B> map<A, B>(covariant StateT<F, S, A> fa, covariant B f(A a)) => fa.map(f);
-  @override StateT<F, S, B> bind<A, B>(covariant StateT<F, S, A> fa, covariant Function1<A, StateT<F, S, B>> f) => fa.bind(f);
+  @override
+  StateT<F, S, A> pure<A>(A a) =>
+      new StateT(_FM, (S s) => _FM.pure(new Tuple2(a, s)));
+  @override
+  StateT<F, S, B> map<A, B>(covariant StateT<F, S, A> fa, covariant B f(A a)) =>
+      fa.map(f);
+  @override
+  StateT<F, S, B> bind<A, B>(covariant StateT<F, S, A> fa,
+          covariant Function1<A, StateT<F, S, B>> f) =>
+      fa.bind(f);
 
   StateT<F, S, S> get() => new StateT(_FM, (S s) => _FM.pure(new Tuple2(s, s)));
-  StateT<F, S, A> gets<A>(A f(S s)) => new StateT(_FM, (S s) => _FM.pure(new Tuple2(f(s), s)));
-  StateT<F, S, Unit> put(S newS) => new StateT(_FM, (_) => _FM.pure(new Tuple2(unit, newS)));
-  StateT<F, S, Unit> modify(S f(S s)) => new StateT(_FM, (S s) => _FM.pure(new Tuple2(unit, f(s))));
+  StateT<F, S, A> gets<A>(A f(S s)) =>
+      new StateT(_FM, (S s) => _FM.pure(new Tuple2(f(s), s)));
+  StateT<F, S, Unit> put(S newS) =>
+      new StateT(_FM, (_) => _FM.pure(new Tuple2(unit, newS)));
+  StateT<F, S, Unit> modify(S f(S s)) =>
+      new StateT(_FM, (S s) => _FM.pure(new Tuple2(unit, f(s))));
 
   StateT<F, S, A> withState<A>(StateT<F, S, A> f(S s)) => get().bind(f);
 }

--- a/lib/src/streaming/conveyor.dart
+++ b/lib/src/streaming/conveyor.dart
@@ -206,7 +206,7 @@ abstract class Conveyor<F, O> implements MonadPlusOps<Conveyor<F, dynamic>, O> {
 
   @override Conveyor<F, B> andThen<B>(Conveyor<F, B> next) => bind((_) => next);
 
-  @override Conveyor<F, B> ap<B>(Conveyor<F, Function1<O, B>> ff) => ff.bind((f) => map(f)); // TODO: optimize
+  @override Conveyor<F, B> ap<B>(Conveyor<F, Function1<O, B>> ff) => ff.bind(map); // TODO: optimize
 
   @override Conveyor<F, B> replace<B>(B replacement) => map((_) => replacement);
 }

--- a/lib/src/trampoline.dart
+++ b/lib/src/trampoline.dart
@@ -6,19 +6,24 @@ part of dartz;
 
 abstract class Trampoline<A> implements MonadOps<Trampoline, A> {
   Trampoline<B> pure<B>(B b) => new _TPure(b);
-  @override Trampoline<B> map<B>(B f(A a)) => bind((a) => pure(f(a)));
-  @override Trampoline<B> bind<B>(Function1<A, Trampoline<B>> f) => new _TBind(this, cast(f));
+  @override
+  Trampoline<B> map<B>(B f(A a)) => bind((a) => pure(f(a)));
+  @override
+  Trampoline<B> bind<B>(Function1<A, Trampoline<B>> f) =>
+      new _TBind(this, cast(f));
 
-  @override Trampoline<Tuple2<B, A>> strengthL<B>(B b) => map((a) => tuple2(b, a));
+  @override
+  Trampoline<Tuple2<B, A>> strengthL<B>(B b) => map((a) => tuple2(b, a));
 
-  @override Trampoline<Tuple2<A, B>> strengthR<B>(B b) => map((a) => tuple2(a, b));
+  @override
+  Trampoline<Tuple2<A, B>> strengthR<B>(B b) => map((a) => tuple2(a, b));
 
   A run() {
     _TBind<Object, Object> current = _unsafeGetTBind();
     if (current == null) {
       return _unsafeGetTPure()._a;
     }
-    while(true) {
+    while (true) {
       final fa = current._fa;
       final f = current._f;
       final fabind = fa._unsafeGetTBind();
@@ -36,13 +41,19 @@ abstract class Trampoline<A> implements MonadOps<Trampoline, A> {
     }
   }
 
-  @override Trampoline<B> andThen<B>(Trampoline<B> next) => bind((_) => next);
+  @override
+  Trampoline<B> andThen<B>(Trampoline<B> next) => bind((_) => next);
 
-  @override Trampoline<B> ap<B>(Trampoline<Function1<A, B>> ff) => ff.bind((f) => map(f)); // TODO: optimize
+  @override
+  Trampoline<B> ap<B>(Trampoline<Function1<A, B>> ff) =>
+      ff.bind(map); // TODO: optimize
 
-  @override Trampoline<B> flatMap<B>(Function1<A, Trampoline<B>> f) => new _TBind(this, cast(f));
+  @override
+  Trampoline<B> flatMap<B>(Function1<A, Trampoline<B>> f) =>
+      new _TBind(this, cast(f));
 
-  @override Trampoline<B> replace<B>(B replacement) => map((_) => replacement);
+  @override
+  Trampoline<B> replace<B>(B replacement) => map((_) => replacement);
 
   _TPure<A> _unsafeGetTPure();
 
@@ -53,7 +64,8 @@ class _TPure<A> extends Trampoline<A> {
   final A _a;
   _TPure(this._a);
 
-  @override _TPure<A> _unsafeGetTPure() => this;
+  @override
+  _TPure<A> _unsafeGetTPure() => this;
   _TBind<A, dynamic> _unsafeGetTBind() => null;
 }
 
@@ -71,4 +83,5 @@ final Monad<Trampoline> TrampolineM = new MonadOpsMonad((a) => new _TPure(a));
 Trampoline<T> treturn<T>(T t) => new _TPure(t);
 
 final Trampoline<Unit> tunit = new _TPure(unit);
-Trampoline<T> tcall<T>(Function0<Trampoline<T>> thunk) => new _TBind(cast(tunit), (_) => thunk());
+Trampoline<T> tcall<T>(Function0<Trampoline<T>> thunk) =>
+    new _TBind(cast(tunit), (_) => thunk());

--- a/lib/src/unsafe/io.dart
+++ b/lib/src/unsafe/io.dart
@@ -24,7 +24,7 @@ Future unsafeIOInterpreter(IOOp io) {
     return new Future.error(io.failure);
 
   } else if (io is OpenFile) {
-    return new File(io.path).open(mode: io.openForRead ? FileMode.READ : FileMode.WRITE).then((f) => new _RandomAccessFileRef(f));
+    return new File(io.path).open(mode: io.openForRead ? FileMode.read : FileMode.write).then((f) => new _RandomAccessFileRef(f));
 
   } else if (io is CloseFile) {
     return unwrapFileRef(io.file).then((f) => f.close().then((_) => unit));


### PR DESCRIPTION
optimizing bind-map usage:  
  
`ff.bind((f) => map(f))` is replaced by `ff.bind(map)`