### PR TITLE
Make Task.both fail fast.

### DIFF
--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -44,7 +44,7 @@ class Task<A> implements MonadCatchOps<Task, A> {
   @override Task<B> replace<B>(B replacement) => map((_) => replacement);
 
   Task<Tuple2<A, B>> both<B>(Task<B> that) => Task(() =>
-    Future.wait([_run(), that._run()])
+    Future.wait([_run(), that._run()], eagerError: true)
       .then((value) => tuple2(cast(value[0]), cast(value[1])))
   );
 

--- a/test/task_test.dart
+++ b/test/task_test.dart
@@ -36,6 +36,25 @@ void main() {
     expect(result.value1 < Duration(milliseconds: 1100), true);
   });
 
+  test("Task.both will fail on first error", () async {
+    final one = Task.value(1).delayBy(Duration(seconds: 3));
+    final two = Task.failed<int>('boom!').delayBy(Duration(seconds: 1));
+
+    final result = await one
+        .both(two)
+        .map((t) => t.value1 + t.value2)
+        .attempt()
+        .timed
+        .run();
+
+    final elapsed = result.value1;
+    final value = result.value2;
+
+    expect(value, left('boom!'));
+    expect(elapsed >= Duration(seconds: 1), true);
+    expect(elapsed < Duration(milliseconds: 1100), true);
+  });
+
   test("Task.bracket", () async {
     var count = 0;
 


### PR DESCRIPTION
This is subjective, but I think this should have been the behavior from when I originally wrote this function.

When a either task fails, the other is silently dropped, which probably isn't ideal either but seem to be somewhat limited by `Future.wait`.