### PR TITLE
Add catchAsync for Eithers

### DIFF
--- a/lib/src/either.dart
+++ b/lib/src/either.dart
@@ -213,6 +213,14 @@ Either<dynamic, A> catching<A>(Function0<A> thunk) {
   }
 }
 
+Future<Either<dynamic, A>> catchAsync<A>(Function0<Future<A>> f) async {
+  try {
+    return Right(await f());
+  } catch (e) {
+    return Left(e);
+  }
+}
+
 class EitherMonad<L> extends MonadOpsMonad<Either<L, dynamic>> {
   EitherMonad(): super(right);
 }

--- a/test/either_test.dart
+++ b/test/either_test.dart
@@ -103,4 +103,20 @@ void main() {
       expect(right.value, 2);
     });
   });
+
+  group("catchAsync", () {
+    test("successful future", () async {
+      expect(await catchAsync(() => Future.value(2)), right(2));
+    });
+
+    test("failed future", () async {
+      final error = Exception("foobar");
+      expect(await catchAsync(() => Future.error(error)), left(error));
+    });
+
+    test("throwing synchronous function body", () async {
+      final error = Exception("foobar");
+      expect(await catchAsync(() => throw error), left(error));
+    });
+  });
 }


### PR DESCRIPTION
Closes #105. Allows to use `catchAsync` in place of `catching` for asynchronous contexts.

Example usage:

```dart
  Future<Either<dynamic, FooBar>> doAsyncThings() {
    return catchAsync(() async {
      final foo = await asyncAction();
      final bar = await asyncAction();
      return foo + bar;
    });
  }
```