### PR TITLE
Fix Task.flatTap signature.

### DIFF
--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -52,7 +52,7 @@ class Task<A> implements MonadCatchOps<Task, A> {
 
   Task<A> delayBy(Duration duration) => sleep(duration).productR(this);
 
-  Task<A> flatTap<B>(Task<B> that) => productL(that);
+  Task<A> flatTap<B>(Function1<A, Task<B>> f) => flatMap((a) => f(a).replace(a));
 
   Task<A> guarantee(Task<void> finalizer) => Task(() => _run().whenComplete(() => finalizer._run()));
 

--- a/test/task_test.dart
+++ b/test/task_test.dart
@@ -24,6 +24,19 @@ void main() {
     expect(result.fold(id, id) is FormatException, true);
   });
 
+  test("Task flatTap", () async {
+    var count = 0;
+
+    final one = Task.value(1);
+    final inc = (int i) => Task.delay(() => count += i).voided;
+
+    await one.flatTap(inc).run();
+    expect(count, 1);
+
+    await one.flatTap(inc).flatTap(inc).run();
+    expect(count, 3);
+  });
+
   test("Task.both (concurrent)", () async {
     final one = Task.value(1).delayBy(Duration(seconds: 1));
     final two = Task.value(2).delayBy(Duration(seconds: 1));


### PR DESCRIPTION
I just realized I really goofed up the `flatTap` signature when I implemented it a while back. This fixes the signature so the dependent task takes the computed value as an argument.