### PR TITLE
Fix IMap.getKey() to return None() when a non-existent key is checked

### DIFF
--- a/lib/src/imap.dart
+++ b/lib/src/imap.dart
@@ -364,9 +364,19 @@ class _NonEmptyIMapAVLNode<K, V> extends _IMapAVLNode<K, V> {
       if (o == Ordering.EQ) {
         return some(current._k);
       } else if (o == Ordering.LT) {
-        current = current._left._unsafeGetNonEmpty()!;
+        final l = current._left._unsafeGetNonEmpty();
+        if (l != null) {
+          current = l;
+        } else {
+          return none();
+        }
       } else {
-        current = current._right._unsafeGetNonEmpty()!;
+        final r = current._right._unsafeGetNonEmpty();
+        if (r != null) {
+          current = r;
+        } else {
+          return none();
+        }
       }
     }
     return none();

--- a/test/imap_test.dart
+++ b/test/imap_test.dart
@@ -60,6 +60,11 @@ void main() {
       final m = dynamicM as IMap<Tuple2<int, int>, int>;
       return m.keys().all((t) => m.getKey(tuple2(t.value1, 0)) == some(t));
     }));
+    qc.check(forall(complexIMaps, (dynamicM) {
+      final m = dynamicM as IMap<Tuple2<int, int>, int>;
+      return m.keys().any((t) => m.getKey(tuple2(t.value1 + 1, 0)) == none());
+    }));
+
   });
 
   test("pair iterable", () => qc.check(forall(intIMaps, (dynamicM) {


### PR DESCRIPTION
Using IMap.getKey() to check if a key exists should return None() if the key doesn't exist. Instead it was throwing "Null check operator used on a null value".

This fix basically copies the code from the value .get() method that does correctly return None()